### PR TITLE
Lambda VPC config

### DIFF
--- a/ife-lambda/main.tf
+++ b/ife-lambda/main.tf
@@ -96,4 +96,9 @@ resource "aws_lambda_function" "ife_lambda_authorizer" {
   }
 
   tags = var.tags
+
+  vpc_config {
+    subnet_ids         = var.lambda_subnet_ids
+    security_group_ids = var.lambda_security_group_ids
+  }
 }

--- a/ife-lambda/variables.tf
+++ b/ife-lambda/variables.tf
@@ -23,3 +23,16 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "lambda_subnet_ids" {
+  description = "VPC subnets for Lambda"
+  type        = list(string)
+  default     = []
+}
+
+variable "lambda_security_group_ids" {
+  description = "SG IDs for Lambda, should at least allow all outbound"
+  type        = list(string)
+  default     = []
+}
+

--- a/main.tf
+++ b/main.tf
@@ -62,6 +62,9 @@ module "ife_authorization_lambda" {
   param_store_client_prefix = local.param_store_client_prefix
 
   lambda_log_retention = local.lambda_log_retention
+  lambda_subnet_ids = var.lambda_subnet_ids
+  lambda_security_group_ids = var.lambda_security_group_ids
+
   tags                 = local.tags
 }
 

--- a/main.tf
+++ b/main.tf
@@ -61,11 +61,11 @@ module "ife_authorization_lambda" {
   env_user_pool_id          = module.ife_cognito.cognito_pool_id
   param_store_client_prefix = local.param_store_client_prefix
 
-  lambda_log_retention = local.lambda_log_retention
-  lambda_subnet_ids = var.lambda_subnet_ids
+  lambda_log_retention      = local.lambda_log_retention
+  lambda_subnet_ids         = var.lambda_subnet_ids
   lambda_security_group_ids = var.lambda_security_group_ids
 
-  tags                 = local.tags
+  tags = local.tags
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -114,3 +114,16 @@ variable "lambda_log_retention" {
   type        = number
   default     = 30
 }
+
+variable "lambda_subnet_ids" {
+  description = "VPC subnets for Lambda"
+  type        = list(string)
+  default     = []
+}
+
+variable "lambda_security_group_ids" {
+  description = "SG IDs for Lambda, should at least allow all outbound"
+  type        = list(string)
+  default     = []
+}
+


### PR DESCRIPTION
adds support for VPC subnet configuration required by AWS config rule **lambda-inside-vpc**:
https://docs.aws.amazon.com/config/latest/developerguide/lambda-inside-vpc.html